### PR TITLE
feat: allow different jaspar DB sources

### DIFF
--- a/R/motifs.R
+++ b/R/motifs.R
@@ -1,28 +1,33 @@
 #' getJasparMotifs
 #'
 #' Function to get motifs from JASPAR database
-#' @param species Which species?  use eithe jaspar code or latin name. 
+#' @param species Which species?  use eithe jaspar code or latin name.
 #' default is 'Homo sapiens'
 #' @param collection Which collection to use?  default is 'CORE'
-#' @param ... additional arguments to opts for 
+#' @param jaspar_db Which JASPAR database? default is `JASPAR2016::JASPAR2016`
+#' @param ... additional arguments to opts for
 #' \code{\link[TFBSTools]{getMatrixSet}}
 #' @details Simply a wrapper function for \code{\link[TFBSTools]{getMatrixSet}}
 #'  that calls JASPAR2016 database using \code{\link[JASPAR2016]{JASPAR2016}}
 #' @return \code{\link[TFBSTools]{PFMatrixList}}
 #' @export
-#' @examples 
-#' 
+#' @examples
+#'
 #' motifs <- getJasparMotifs()
-#' 
-#' 
-getJasparMotifs <- function(species = "Homo sapiens", 
-                              collection = "CORE", ...) {
+#'
+#' # use the JASPAR2020 database
+#' motifs <- getJasparMotifs(jaspar_db = JASPAR2020::JASPAR2020)
+#'
+getJasparMotifs <- function(species = "Homo sapiens",
+                            collection = "CORE",
+                            jaspar_db = JASPAR2016::JASPAR2016,
+                            ...) {
   opts <- list()
   opts["species"] <- species
   opts["collection"] <- collection
   opts <- c(opts, list(...))
-  out <- TFBSTools::getMatrixSet(JASPAR2016::JASPAR2016, opts)
-  if (!isTRUE(all.equal(TFBSTools::name(out), names(out)))) 
+  out <- TFBSTools::getMatrixSet(jaspar_db, opts)
+  if (!isTRUE(all.equal(TFBSTools::name(out), names(out))))
     names(out) <- paste(names(out), TFBSTools::name(out), sep = "_")
   return(out)
 }


### PR DESCRIPTION
Hi @AliciaSchep,

I've added a param to `getJasparMotifs()` to allow users to specify different versions of the JASPAR motif database. Please take a look at let me know if I can do anything to make this PR easier to accept.

Thanks! 